### PR TITLE
Script to prepare input file for pre-trained model

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,27 @@ python qasrl/pipelines/afirst_pipeline_sequential.py \
 ```
 which will write complete model predictions at `out.jsonl`.
 
+#### Input file format
+
+The format of the input file should be jsonl, where each sentence has a dictionary
+ representing him. The must-have keys are "sentenceId", "sentenceTokens", "verbEntries".
+
+So for the sentence "Both occur suddenly.", The representive json should look as
+  follows:
+
+```json
+{"sentenceId":"1",
+"sentenceTokens":["Both","occur","suddenly","."],
+"verbEntries":{"1":{"verbIndex":1,"verbInflectedForms":{"stem":"occur","presentSingular3rd":"occurs","presentParticiple":"occurring","past":"occurred","pastParticiple":"occurred"}}}}
+```
+
+1. "sentenceId": Is copied as is to the output file.
+2. "sentenceTokens": Its value is a list of the sentence's tokens.
+3. "verbEntries": Its value is a dictionary, where each key is a string representing
+ the index of a verb token in the sentence, and the inner dict should include verbIndex
+  (as an integer), and verbInflectedForms.
+ 
+
 ### Hyperparameter tuning
 
 To do hyperparameter tuning, first you generate the config files for all hyperparameter settings.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ which will write complete model predictions at `out.jsonl`.
 #### Input file format
 
 The format of the input file should be jsonl, where each sentence has a dictionary
- representing him. The must-have keys are "sentenceId", "sentenceTokens", "verbEntries".
+ representing it. The must-have keys are "sentenceId", "sentenceTokens", "verbEntries".
 
 So for the sentence "Both occur suddenly.", The representive json should look as
   follows:
@@ -96,7 +96,9 @@ So for the sentence "Both occur suddenly.", The representive json should look as
 3. "verbEntries": Its value is a dictionary, where each key is a string representing
  the index of a verb token in the sentence, and the inner dict should include verbIndex
   (as an integer), and verbInflectedForms.
- 
+
+There is a conversion script that outputs this format of a file under 
+[`qasrl/scripts/utils/prepare_input_file.py`](qasrl/scripts/utils/prepare_input_file.py). 
 
 ### Hyperparameter tuning
 

--- a/data/input.txt
+++ b/data/input.txt
@@ -1,0 +1,2 @@
+TQA:T_0058_1	Both occur suddenly.
+TQA:T_0059_0	A landslide happens when a large amount of soil and rock suddenly falls down a slope because of gravity.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ networkx
 overrides==3.1.0
 scikit-learn==0.22.2
 pytorch-pretrained-bert==0.6.0
-spacy
-lemminflect
+spacy==2.2.4
+lemminflect==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ networkx
 overrides==3.1.0
 scikit-learn==0.22.2
 pytorch-pretrained-bert==0.6.0
+spacy
+lemminflect

--- a/scripts/utils/prepare_input_file.py
+++ b/scripts/utils/prepare_input_file.py
@@ -1,0 +1,76 @@
+
+"""
+This script reads a text file and converting it to jsonl file in the matching format
+for qasrl pre-trained models.
+The expected format of the input file for this script is:
+<SENTENCE_ID>\t<SENTENCE>
+Where each sentence should be in a different line.
+
+Usage:
+python scripts/utils/prepare_input_file.py --input data/input.txt --output data/output.jsonl
+"""
+
+from argparse import ArgumentParser
+import json
+import spacy
+from lemminflect import getInflection, getLemma  # https://github.com/bjascob/LemmInflect
+
+
+TAGS_FOR_LEMMINFLECT = {"past": "VBD",
+                        "presentSingular3rd": "VBZ",
+                        "presentParticiple": "VBG",
+                        "pastParticiple": "VBN"}
+SEPARATOR = '\t'
+
+
+def convert_sentences(path_to_input, output_path):
+    """
+    converts an input file to a format that matches qasrl-modeling input file format.
+    path_to_input is the path to the file to convert, and the expected format of the
+    content in this file is "<SENTENCE_ID>\t<SENTENCE>\n" (Each line is a different
+    sentence).
+    """
+
+    tokenizer = spacy.load("en_core_web_sm")
+
+    with open(path_to_input, 'rt') as f:
+        all_sentences = f.readlines()
+
+    with open(output_path, 'wt') as out:
+        for line in all_sentences:
+            id_sentence, sentence_str = tuple(line.strip().split(SEPARATOR))
+            tokens = tokenizer(sentence_str)
+            line_dict = {"sentenceId": id_sentence, "sentenceTokens": [],
+                         "verbEntries": {}}
+            for i in range(len(tokens)):
+                current_token_txt = tokens[i].text
+                line_dict["sentenceTokens"].append(current_token_txt)
+                if tokens[i].pos_ == "VERB":
+                    inflect_verb(i, line_dict, current_token_txt)
+            out.write(json.dumps(line_dict) + '\n')
+
+
+def inflect_verb(verb_index, line_dict, current_token_txt):
+    """
+    builds a dictionary of the given verb inflections, and update line_dict with those
+    inflections.
+    """
+    stem = getLemma(current_token_txt, upos='VERB')[0]
+    inflected_forms = {"stem": stem}
+    inflected_forms.update({k: getInflection(stem, tag=TAGS_FOR_LEMMINFLECT[k])[0]
+                            for k in TAGS_FOR_LEMMINFLECT})
+    line_dict["verbEntries"][str(verb_index)] = {"verbIndex": verb_index,
+                                                 "verbInflectedForms": inflected_forms}
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('--input', '-i', required=True,
+                        help="path file to convert, each line represents a sentence "
+                             "<ID>\\t<SENTENCE>")
+    parser.add_argument('--output', '-o', required=True,
+                        help="path to jsonl output, that will be used as an input for "
+                             "the pre-trained model")
+    args = parser.parse_args()
+
+    convert_sentences(args.input, args.output)


### PR DESCRIPTION
Hi @julianmichael .
After investigating how the input file to use for a pre-trained model should look like, I've wrote a script that creates a jsonl file mathces that format.
The input of the script I've wrote should be a file where each line contains a sentence and its ID:
<ID>\t<SENTENCE>
and the output of this script is a jsonl file with the correct format for qasrl-modeling pre-trained model.

I've added doccumantation in the README about how exactlythis file should look like, and also a detailed documantation as part of the script I've wrote (under qasrl/scripts/utils/prepare_input_file.py).
I've also added to the repo requirements 2 packages that are used for this script (spacy and lemminflect).

I hope you will find my contribution useful :)